### PR TITLE
Fixed Docusaurus editUrl

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/metaplex/docs/',
+          editUrl: 'https://github.com/metaplex/docs/tree/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Super tiny change. Currently, clicking the edit button takes you to an incorrect link, so this fix just makes the edit button work correctly. 