### PR TITLE
Fixing candy-machine-cli.ts location

### DIFF
--- a/docs/create-candy/04-upload-assets.md
+++ b/docs/create-candy/04-upload-assets.md
@@ -51,7 +51,7 @@ In this example, we will be uploading files from our "assets" folder onto the de
 
 command:
 ```
-ts-node ~/metaplex/js/packages/cli/src/candy-machine-cli.ts upload ./assets --env devnet --keypair ~/.config/solana/devnet.json
+ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts upload ./assets --env devnet --keypair ~/.config/solana/devnet.json
 ```
 
 expected output:


### PR DESCRIPTION
If you follow the tutorial you will have candy-machine-cli.ts in `~/metaplex-foundation/metaplex/js/packages/cli/src/` but this part of the tutorial says `~/metaplex/js/packages/cli/src/`. So I think `metaplex-foundation/` is missing 