### PR TITLE
Missing \ in Docs for Step 6. Update Candy Machine

### DIFF
--- a/docs/create-candy/07-update-cm.md
+++ b/docs/create-candy/07-update-cm.md
@@ -10,7 +10,7 @@ ts-node ~/metaplex/js/packages/cli/src/candy-machine-cli.ts \
   update_candy_machine \
   --env devnet \
   --keypair ~/.config/solana/devnet.json \
-  -p 1
+  -p 1 \
   --date "17 Oct 2021 00:00:00 GMT"
 ```
 


### PR DESCRIPTION
Hey team, thanks for all these resources! Added a `\` after `-p`, so that you can run the whole command (including `--date`) without getting cut off.